### PR TITLE
Brief accounting of eht-imaging and pycbc libraries.

### DIFF
--- a/body.tex
+++ b/body.tex
@@ -165,6 +165,33 @@ NIPY (neuroimaging) \cite{millman2007analysis}, and Pangeo (earth science) \cite
 % we should have an example of how these tools may all be used in an
 % example analysis.  maybe one of the ones mentioned in the abstract?
 
+The \tt{eht-imaging} library developed by the Event Horizon Telescope 
+collabortion relies on many components of the scientific Python ecosystem.
+NumPy arrays were used to store and manipulate numerical data at every step
+in the processing chain: from raw data through calibration and image 
+reconstruction.
+Scipy was used to provide tools used in general image processing such as 
+filtering and image alignment, while scikit\_image provided higher-level
+functionality such as edge filters and Hough transforms.
+Other components of Scipy are used throughout the library, such as the
+\tt{scipy.optimize} package for handling general optimization tasks.
+Matplotlib is used for visualizing data throughout the analysis pipeline,
+including the generation of the final image of the black hole.
+% N.B. - most of this comes from introspecting the Image class defined in
+% ehtim/image.py. 
+
+Tools for analyzing data from gravitational wave observatories such as LIGO
+and Virgo are provided by the \tt{pycbc} package, which was used in the first
+detection of gravitationaly waves \cite{abbott2016observation} and in 
+on-going analysis of data from LIGO and Virgo.
+\tt{pycbc} make extensive use of the scientific Python ecosystem.
+The time-series data from the interferometers are stored in NumPy arrays,
+while the \tt{scipy.signal} is used to construct and apply filters to the
+data.
+Matplotlib is used to visualize data at all points along the analysis chain
+including raw data from the instrumentation and the time-frequency 
+visualization of the ``chirp'' from the binary black hole merger.
+
 Exposing array programming primitives, as well as the surrounding ecosystem of
 tools, in Python---an interpreted language---creates an ideal environment for
 interactive, exploratory data analysis where users may iteratively inspect,

--- a/references.bib
+++ b/references.bib
@@ -2213,6 +2213,18 @@ We illustrate with C code that provides for inline generation of both normal and
   publisher={IOP Publishing}
 }
 
+@article{abbott2016observation,
+  title={Observation of gravitational waves from a binary black hole merger},
+  author={Abbott, Benjamin P and Abbott, Richard and Abbott, TD and Abernathy, MR and Acernese, Fausto and Ackley, Kendall and Adams, Carl and Adams, Thomas and Addesso, Paolo and Adhikari, RX and others},
+  journal={Physical review letters},
+  volume={116},
+  number={6},
+  pages={061102},
+  year={2016},
+  publisher={APS}
+}
+
+
 @incollection{pytorch,
 title = {PyTorch: An Imperative Style, High-Performance Deep Learning Library},
 author = {Paszke, Adam and Gross, Sam and Massa, Francisco and Lerer, Adam and Bradbury, James and Chanan, Gregory and Killeen, Trevor and Lin, Zeming and Gimelshein, Natalia and Antiga, Luca and Desmaison, Alban and Kopf, Andreas and Yang, Edward and DeVito, Zachary and Raison, Martin and Tejani, Alykhan and Chilamkurthy, Sasank and Steiner, Benoit and Fang, Lu and Bai, Junjie and Chintala, Soumith},


### PR DESCRIPTION
I've added a few sentences about how packages from the scientific Python ecosystem were used in two examples: the direct image of the M87 supermassive blackhole (`eht-imaging`) and the discovery of gravitational waves (`pycbc`).

Per Stefan's suggestion, I focused mostly on the black hole imaging example and the `eht-imaging` package specifically. There are [other repos](https://github.com/eventhorizontelescope/2019-D01-02) from the EHT group that set up specific imaging pipelines to reproduce the final image (`eht-imaging` is included of course) but they are a little harder to introspect. I focused most of my attention on the `Image` class that is defined in `ehtim/image.py` as that seems to be pretty fundamental to the analysis. Of course, `eht-imaging` is a library, and I can't guarantee that everything that is defined in the library was used in the *specific analysis* that produced the black hole image.

I mostly focused on the uses of `numpy`, `scipy`, and `matplotlib`, though there are other dependencies (`scikit-image`, `networkx`, and `astropy`) that are included. A quick grepping showed that `networkx` was used for image comparisons, `astropy` is used in quite a few places, primarily for I/O and time/coordinate transformations, and canny filters and Hough transforms from `scikit-image` are used in methods of `Image`. 

I tried to pack as much into as few sentences as I could so that you'd have an easy time cutting/re-wording down to what was important.

I also included the PyCBC example because I had taken a look at that previously. I'm happy to expand on it if you'd like, or feel free to ignore (N.B. I also modified `references.bib` for this section, so if you cut it out you can ignore the bib changes).

Let me know if you want me to take a closer look or develop one or both of the examples further. 