### PR TITLE
Modified pycbc and eht-imaging text - more explicit.

### DIFF
--- a/body.tex
+++ b/body.tex
@@ -179,19 +179,21 @@ which vastly extends the basic image processing tools provided by SciPy.
 Other components of Scipy are used throughout the library, such as the
 \code{scipy.optimize} package for handling general optimization tasks.
 NetworkX \cite{SciPyProceedings_11} (the standard package for complex
-network analysis) is used for image comparisons.
+network analysis) is used for analysis of consistency among image
+comparisons.
 Astropy \cite{astropy:2013, astropy:2018} (a community-developed astronomy
-libarary) is used in quite a few places,
-primarily for I/O and time/coordinate transformations.
+library) is used throughout the library,
+primarily for I/O from standard astronomical file formats and time/coordinate
+transformations.
 Matplotlib (the core library for generating publication-ready figures
 and visualizations) is used for visualizing data throughout the analysis pipeline,
 including the generation of the final image of the black hole.
 % N.B. - most of this comes from introspecting the Image class defined in
-% ehtim/image.py. 
+% ehtim/image.py and grepping the dependencies in requirements.txt
 
 Tools for analyzing data from gravitational wave observatories such as LIGO
 and Virgo are provided by the \code{pycbc} package, which was used in the first
-detection of gravitationaly waves \cite{abbott2016observation} and in 
+detection of gravitational waves \cite{abbott2016observation} and in 
 on-going analysis of data from LIGO and Virgo.
 \code{pycbc} make extensive use of the scientific Python ecosystem.
 The time-series data from the interferometers are stored in NumPy arrays,
@@ -199,7 +201,9 @@ while the \code{scipy.signal} is used to construct and apply filters to the
 data.
 Matplotlib is used to visualize data at all points along the analysis chain
 including raw data from the instrumentation and the time-frequency 
-visualization of the ``chirp'' from the binary black hole merger.
+visualization of the ``chirps'' that result from mergers of compact binaries
+such as black holes\cite{abbott2016observation} and
+neutron stars\cite{abbott2017multi}.
 
 The rich ecosystem of tools building on NumPy and the larger community
 of scientists and programmers using those tools mean that NumPy has a

--- a/references.bib
+++ b/references.bib
@@ -1694,6 +1694,11 @@ urldate = {2019-1-23}
   publisher={APS},
 	url={https://doi.org/10.1103/PhysRevLett.119.161101}
 }
+@article{abbott2017multi,
+  title={Multi-messenger observations of a binary neutron star merger},
+  author={Abbott, Benjamin P and Bloemen, S and Canizares, P and Falcke, H and Fender, RP and Ghosh, S and Groot, P and Hinderer, T and H{\"o}randel, JR and Jonker, PG and others},
+  year={2017}
+}
 
 @online{GW150914-Python,
 author={Michele Vallisneri and Jonah Kanner and Roy Williams and Alan Weinstein and Branson Stephens},


### PR DESCRIPTION
In #51 , I had not provided the same level of detail for the `networkx` and `astropy` dependencies as I did for `numpy`, `scipy`, and `matplotlib`. I've re-examined the `eht-imaging` code in more detail and revised the wording in the paper to be a bit more explicit regarding these dependencies. The change is not strictly necessary, but I wanted to go back and ensure that the statements were as accurate as possible. The changes may include too much detail, but I wanted to make sure enough information was included for you to be able to make an informed decision about the appropriate level of detail.

I've also added a reference to *kilonova* events, i.e. neutron  star mergers, to the end of the `pycbc` example. The kilonova detection by GWOs (along with simultaneous confirmations from other types of observatories) is another hugely important scientific discovery (have you seen [this version of the periodic table](https://commons.wikimedia.org/wiki/File:Nucleosynthesis_periodic_table.svg) that highlights the origin of the elements - look at all the purple squares!) Feel free to remove if it makes the wording too clunky or the paragraph too long.