### PR TITLE
Minor edit, fix Dask-CuPy-RAPIDS reference

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -299,14 +299,12 @@
   url={https://archive.siam.org/news/news.php?id=1595}
 }
 
-% RG: there are no conference proceedings; I asked Peter to put this on Zenodo
-% so we can reference better.
 @misc{entschev2019,
   author={P. Entschev},
   title={{D}istributed Multi-{GPU} Computing with {D}ask, {C}u{P}y and {RAPIDS}},
   howpublished={EuroPython},
   year={2019},
-  url={https://ep2019.europython.eu/talks/fX8dJsD-distributed-multi-gpu-computing-with-dask-cupy-and-rapids}
+  url={https://www.slideshare.net/PeterAndreasEntschev/dask-cupy-rapids-ep2019}
 }
 
 @article{millman2011python,


### PR DESCRIPTION
Zenodo was not really doable due to needing to choose a license there.